### PR TITLE
bug fix: unparsed argument in aria_to_robomimic.py

### DIFF
--- a/egomimic/scripts/aria_process/aria_to_robomimic.py
+++ b/egomimic/scripts/aria_process/aria_to_robomimic.py
@@ -113,7 +113,7 @@ def single_file_conversion(dataset, mps_sample_path, filename, hand, single_acti
     ## get camera matrices
     vrs_data_provider = data_provider.create_vrs_data_provider(vrsfile)
 
-    transform = slam_to_rgb()
+    transform = slam_to_rgb(vrs_data_provider)
 
     for t in range(frame_length + 1):
         # if t >= 2000:


### PR DESCRIPTION
 egomimic/scripts/aria_process/aria_to_robomimic.py line 116: vrs_data_provider is not parsed into slam_to_rgb() function.

In the current version:
```python
    ## get camera matrices
    vrs_data_provider = data_provider.create_vrs_data_provider(vrsfile)

    transform = slam_to_rgb()
```

This would cause exception in the slam_to_rgb() function like:
```txt
File "/home/boruili/EgoMimic/egomimic/scripts/aria process/aria utils.py", line 83, in slam to rgbdevice calibration = provider.get device calibration()AttributeError: 'NoneType' object has no attribute 'get device calibration
```

This can be fixed by simply parsing in the vrs_data_provider to the slam_to_rgb() function, I guess.

```python
    ## get camera matrices
    vrs_data_provider = data_provider.create_vrs_data_provider(vrsfile)

    transform = slam_to_rgb(vrs_data_provider)
```

This is the only modification of this pull request.